### PR TITLE
fixing idle rx redirect bug

### DIFF
--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -960,13 +960,13 @@ HOT_FUNC bool CFlowTable::rx_handle_packet(CTcpPerThreadCtx * ctx,
                 action,
                 port_id);
 
-    if ( action != tPROCESS ) {
-        rx_non_process_packet(action, ctx, mbuf);
+    if ( is_idle ) {
+        rte_pktmbuf_free(mbuf);
         return false;
     }
 
-    if ( is_idle ) {
-        rte_pktmbuf_free(mbuf);
+    if ( action != tPROCESS ) {
+        rx_non_process_packet(action, ctx, mbuf);
         return false;
     }
 


### PR DESCRIPTION
I realized that when I first started TRex, I noticed that the` rx_redirect` stat for both the client and server is increasing even though when there is no traffic being sent from the TRex console. Upon investigating, I realized that the if statement for checking the idle state needs to be moved before checking the action. 