### PR TITLE
Fixing keep alive drop bug

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -624,8 +624,10 @@ static void ctx_timer(void *userdata,
         UNSAFE_CONTAINER_OF_PUSH;
         udp_flow=my_unsafe_container_of(tmr,CUdpFlow,m_keep_alive_timer);
         UNSAFE_CONTAINER_OF_POP;
-        udp_flow->on_tick();
-        ctx->handle_udp_timer(udp_flow);
+        if(tmr->m_root && tmr->m_root->m_count != 0) {
+                udp_flow->on_tick();
+                ctx->handle_udp_timer(udp_flow);
+            }
         }
         break;
     case ttUDP_APP:


### PR DESCRIPTION
This check was needed to ensure that the bucket for the timing wheel is not itself or not empty, another way I found to do this check is to use `if(tmr->m_root && !tmr->m_root->is_self())` instead.  